### PR TITLE
fix(mcp-server): resolve Windows native host collision and CLI detection

### DIFF
--- a/packages/mcp-server/src/doctor/checks/claude-mcp.ts
+++ b/packages/mcp-server/src/doctor/checks/claude-mcp.ts
@@ -2,7 +2,11 @@ import { spawnSync } from 'node:child_process';
 import type { CheckResult } from '../types.js';
 
 export async function checkClaudeMcpRegistration(): Promise<CheckResult> {
-  const exists = spawnSync('claude', ['--version'], { stdio: 'pipe', encoding: 'utf8' });
+  const exists = spawnSync('claude', ['--version'], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
   if (exists.status !== 0) {
     return {
       name: 'mcp.claude',
@@ -12,7 +16,11 @@ export async function checkClaudeMcpRegistration(): Promise<CheckResult> {
     };
   }
 
-  const list = spawnSync('claude', ['mcp', 'list'], { stdio: 'pipe', encoding: 'utf8' });
+  const list = spawnSync('claude', ['mcp', 'list'], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
   if (list.status === 0 && `${list.stdout}${list.stderr}`.includes('onui-local')) {
     return {
       name: 'mcp.claude',

--- a/packages/mcp-server/src/doctor/checks/codex-mcp.ts
+++ b/packages/mcp-server/src/doctor/checks/codex-mcp.ts
@@ -2,7 +2,11 @@ import { spawnSync } from 'node:child_process';
 import type { CheckResult } from '../types.js';
 
 export async function checkCodexMcpRegistration(): Promise<CheckResult> {
-  const exists = spawnSync('codex', ['--version'], { stdio: 'pipe', encoding: 'utf8' });
+  const exists = spawnSync('codex', ['--version'], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
   if (exists.status !== 0) {
     return {
       name: 'mcp.codex',
@@ -12,7 +16,11 @@ export async function checkCodexMcpRegistration(): Promise<CheckResult> {
     };
   }
 
-  const list = spawnSync('codex', ['mcp', 'list'], { stdio: 'pipe', encoding: 'utf8' });
+  const list = spawnSync('codex', ['mcp', 'list'], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
   if (list.status === 0 && `${list.stdout}${list.stderr}`.includes('onui-local')) {
     return {
       name: 'mcp.codex',

--- a/packages/mcp-server/src/setup/configure-claude.ts
+++ b/packages/mcp-server/src/setup/configure-claude.ts
@@ -7,7 +7,11 @@ export interface ClaudeConfigResult {
 }
 
 function commandExists(command: string): boolean {
-  const result = spawnSync(command, ['--version'], { stdio: 'pipe', encoding: 'utf8' });
+  const result = spawnSync(command, ['--version'], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
   return result.status === 0;
 }
 
@@ -23,6 +27,7 @@ export function configureClaudeMcp(cliPath: string): ClaudeConfigResult {
   spawnSync('claude', ['mcp', 'remove', 'onui-local', '--scope', 'user'], {
     stdio: 'pipe',
     encoding: 'utf8',
+    shell: process.platform === 'win32',
   });
 
   const add = spawnSync(
@@ -31,6 +36,7 @@ export function configureClaudeMcp(cliPath: string): ClaudeConfigResult {
     {
       stdio: 'pipe',
       encoding: 'utf8',
+      shell: process.platform === 'win32',
     }
   );
 

--- a/packages/mcp-server/src/setup/configure-codex.ts
+++ b/packages/mcp-server/src/setup/configure-codex.ts
@@ -7,7 +7,11 @@ export interface CodexConfigResult {
 }
 
 function commandExists(command: string): boolean {
-  const result = spawnSync(command, ['--version'], { stdio: 'pipe', encoding: 'utf8' });
+  const result = spawnSync(command, ['--version'], {
+    stdio: 'pipe',
+    encoding: 'utf8',
+    shell: process.platform === 'win32',
+  });
   return result.status === 0;
 }
 
@@ -23,11 +27,13 @@ export function configureCodexMcp(cliPath: string): CodexConfigResult {
   spawnSync('codex', ['mcp', 'remove', 'onui-local'], {
     stdio: 'pipe',
     encoding: 'utf8',
+    shell: process.platform === 'win32',
   });
 
   const add = spawnSync('codex', ['mcp', 'add', 'onui-local', '--', 'node', cliPath, 'mcp'], {
     stdio: 'pipe',
     encoding: 'utf8',
+    shell: process.platform === 'win32',
   });
 
   if (add.status !== 0) {

--- a/packages/mcp-server/src/store/path.test.ts
+++ b/packages/mcp-server/src/store/path.test.ts
@@ -41,4 +41,29 @@ describe('path resolver', () => {
       'HKCU\\Software\\Mozilla\\NativeMessagingHosts\\com.onui.native'
     );
   });
+
+  it('resolves browser-specific win32 native host manifest paths', () => {
+    const originalAppData = process.env.APPDATA;
+    process.env.APPDATA = 'C:\\Users\\onui\\AppData\\Roaming';
+
+    try {
+      const chromePath = getNativeHostManifestPath('win32', 'chrome');
+      const edgePath = getNativeHostManifestPath('win32', 'edge');
+      const firefoxPath = getNativeHostManifestPath('win32', 'firefox');
+
+      expect(new Set([chromePath, edgePath, firefoxPath]).size).toBe(3);
+      expect(chromePath.split(/[\\/]+/)).toContain('chrome');
+      expect(edgePath.split(/[\\/]+/)).toContain('edge');
+      expect(firefoxPath.split(/[\\/]+/)).toContain('firefox');
+      expect(chromePath).toContain('com.onui.native.json');
+      expect(edgePath).toContain('com.onui.native.json');
+      expect(firefoxPath).toContain('com.onui.native.json');
+    } finally {
+      if (originalAppData === undefined) {
+        delete process.env.APPDATA;
+      } else {
+        process.env.APPDATA = originalAppData;
+      }
+    }
+  });
 });

--- a/packages/mcp-server/src/store/path.ts
+++ b/packages/mcp-server/src/store/path.ts
@@ -68,9 +68,9 @@ export function getNativeHostDir(
       return join(configHome, browserDir, 'NativeMessagingHosts');
     }
     case 'win32':
-      return join(getDataDir(platform), 'native-host');
+      return join(getDataDir(platform), 'native-host', browser);
     default:
-      return join(getDataDir(platform), 'native-host');
+      return join(getDataDir(platform), 'native-host', browser);
   }
 }
 


### PR DESCRIPTION
This PR fixes two issues on Windows:

1. **Native Host Manifest Collision**: Each browser (Chrome, Edge, Firefox) now has its own subdirectory for the native host manifest, preventing them from overwriting each other.
2. **CLI Detection**: Added shell: true to spawnSync calls for claude and codex CLIs to ensure they are correctly found on Windows (where they often exist as .cmd wrappers).