### PR TITLE
fix(build): automatically run mcp setup after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "dev": "pnpm --filter @onui/extension dev",
-    "build": "pnpm --filter @onui/extension build",
+    "build": "pnpm run build:all && pnpm run setup:mcp",
+    "build:extension": "pnpm --filter @onui/extension build",
     "build:all": "pnpm --filter @onui/core build && pnpm --filter @onui/mcp-server build && pnpm --filter @onui/extension build",
     "test": "pnpm test:all",
     "test:all": "pnpm --filter @onui/core build && pnpm --filter @onui/mcp-server run test && pnpm --filter @onui/extension test",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "dev": "pnpm --filter @onui/extension dev",
-    "build": "pnpm run build:all && pnpm run setup:mcp",
+    "build": "pnpm run build:all",
+    "build:dev": "pnpm run build:all && pnpm run setup:mcp",
     "build:extension": "pnpm --filter @onui/extension build",
     "build:all": "pnpm --filter @onui/core build && pnpm --filter @onui/mcp-server build && pnpm --filter @onui/extension build",
     "test": "pnpm test:all",


### PR DESCRIPTION
This PR fixes an issue where the Native Messaging host isn't registered by default when developers run \pnpm build\. This resulted in a \Local bridge: unavailable\ error when loading the unpacked extension. By modifying the build script to run \uild:all && setup:mcp\, the native host configuration and MCP server compilation happen seamlessly, making the developer experience smoother.